### PR TITLE
Fix dummy encoder so that it does when there are no categorical features.

### DIFF
--- a/server/analysis/preprocessing.py
+++ b/server/analysis/preprocessing.py
@@ -292,6 +292,7 @@ class DummyEncoder(Preprocess):
             if nv <= 2:
                 raise Exception("Categorical features must have 3+ labels")
 
+        self.n_values = n_values
         self.cat_columnlabels = cat_columnlabels
         self.noncat_columnlabels = noncat_columnlabels
         self.encoder = OneHotEncoder(
@@ -350,7 +351,7 @@ class DummyEncoder(Preprocess):
         return inverted_matrix
 
     def total_dummies(self):
-        return sum(self.encoder.n_values_)
+        return sum(self.n_values)
 
 
 def consolidate_columnlabels(columnlabels):


### PR DESCRIPTION
Previously, the method total_dummies in the preprocessing module's DummyEncoder class depended on the DummyEncoder having been fit with a nonzero number of categorical (i.e. >= 3 values) features.  When there are no categorical features, the correct thing to do is return 0. Instead, the current code in master will raise an AttributeError, because calling OneHotEncoder.fit(...) with no categorical features results in n_values_ remaining undefined.