### PR TITLE
Fix dummy encoder (#175) for real.

### DIFF
--- a/server/analysis/preprocessing.py
+++ b/server/analysis/preprocessing.py
@@ -330,7 +330,12 @@ class DummyEncoder(Preprocess):
         return self.transform(matrix)
 
     def inverse_transform(self, matrix, copy=True):
-        n_values = self.encoder.n_values_
+        n_values = self.n_values
+        # If there are no categorical variables, no transformation happened.
+        if len(n_values) == 0:
+            return matrix
+
+        # Otherwise, this is a dummy-encoded matrix. Transform it back to original form.
         n_features = matrix.shape[-1] - self.encoder.feature_indices_[-1] + len(n_values)
         noncat_start_idx = self.encoder.feature_indices_[-1]
         inverted_matrix = np.empty((matrix.shape[0], n_features))


### PR DESCRIPTION
In #177, I only cleaned up one instance where the dummy encoder / constraint helper depend on the OneHotEncoder having by fit with at least 1 categorical variable.  This PR completely fixes these dependencies by either removing them or checking that there is at least 1 categorical variable before relying on them.

For example, in the dummy encoder's inverse_transform, if there are no categorical variables, then the function immediately returns the input matrix (as it never got transformed to begin with). Otherwise, it will perform the actual inverse transform logic.

Tested it by running the service locally, uploading data to the tuning session, and seeing that the celery jobs for recommending the new configuration all succeed.