### PR TITLE
add support for user defined target objective

### DIFF
--- a/client/driver/LatencyUDF.py
+++ b/client/driver/LatencyUDF.py
@@ -1,0 +1,43 @@
+#
+# OtterTune - LatencyUDF.py
+#
+# Copyright (c) 2017-18, Carnegie Mellon University Database Group
+#
+
+import sys
+import json
+from collections import OrderedDict
+
+
+def main():
+    if (len(sys.argv) != 2):
+        raise Exception("Usage: python udf.py [Output Directory]")
+
+    with open(sys.argv[1] + "/summary.json", "r") as f:
+        conf = json.load(f,
+                         encoding="UTF-8",
+                         object_pairs_hook=OrderedDict)
+        start_time = conf['start_time']
+        end_time = conf['end_time']
+
+    with open(sys.argv[1] + "/metrics_before.json", "r") as f:
+        conf_before = json.load(f,
+                                encoding="UTF-8",
+                                object_pairs_hook=OrderedDict)
+        conf_before['global']['udf'] = OrderedDict([("latency", "0")])
+
+    with open(sys.argv[1] + "/metrics_after.json", "r") as f:
+        conf_after = json.load(f,
+                               encoding="UTF-8",
+                               object_pairs_hook=OrderedDict)
+        conf_after['global']['udf'] = OrderedDict([("latency", str(end_time - start_time))])
+
+    with open(sys.argv[1] + "/metrics_before.json", "w") as f:
+        f.write(json.dumps(conf_before, indent=4))
+
+    with open(sys.argv[1] + "/metrics_after.json", "w") as f:
+        f.write(json.dumps(conf_after, indent=4))
+
+
+if __name__ == "__main__":
+    main()

--- a/client/driver/fabfile.py
+++ b/client/driver/fabfile.py
@@ -162,6 +162,12 @@ def get_result():
     local(cmd)
 
 
+@task
+def add_udf():
+    cmd = 'sudo python3 ./LatencyUDF.py ../controller/output/'
+    local(cmd)
+
+
 def _ready_to_start_controller():
     return (os.path.exists(CONF['oltpbench_log']) and
             'Warmup complete, starting measurements'
@@ -207,6 +213,9 @@ def loop():
     stop_controller()
 
     p.join()
+
+    # add user defined target objective
+    # add_udf()
 
     # upload result
     upload_result()

--- a/server/website/website/parser/base.py
+++ b/server/website/website/parser/base.py
@@ -164,10 +164,12 @@ class BaseParser(object, metaclass=ABCMeta):
         metric_data = {}
         for name, metadata in list(self.numeric_metric_catalog_.items()):
             value = metrics[name]
-            if metadata.metric_type == MetricType.COUNTER or \
-                    metadata.metric_type == MetricType.STATISTICS:
+            if metadata.metric_type == MetricType.COUNTER:
                 converted = self.convert_integer(value, metadata)
                 metric_data[name] = float(converted) / observation_time
+            elif metadata.metric_type == MetricType.STATISTICS:
+                converted = self.convert_integer(value, metadata)
+                metric_data[name] = float(converted)
             else:
                 raise Exception(
                     'Unknown metric type for {}: {}'.format(name, metadata.metric_type))


### PR DESCRIPTION
Currently, we test OtterTune on Postgres for throughput target objective.  The way we get the throughput is calculating changes between 'pg_stat_database.xact_commit' in metric_before and metric_after files, and divides the change by the observation time. We define the metric for throughput as follows. 

https://github.com/cmu-db/ottertune/blob/87c356655a4030123d4eec8b72453d4c12e49937/server/website/website/parser/postgres.py#L68-L70

However, it becomes a problem when we do not have the related metric in metric files for some target objectives. e.g. when we want to get the latency, it's better to have  the start_time and end_time of the transaction/query, and then we can measure the latency as its time interval.  But Postgres does not have internal metric like that. 

In this PR, we fix the latency by adding a user defined metric  (i.e.  "udf.latency") in the metric files. We get the start time and end time from other monitoring tools like OLTP-Bench, and add it in the metric file in the client side. In the server side, you may want to add "udf.latency" in the metric fixture. The following is 'pg_stat_database.xact_commit' fixture.
 https://github.com/cmu-db/ottertune/blob/87c356655a4030123d4eec8b72453d4c12e49937/server/website/website/fixtures/postgres-94_metrics.json#L299-L309

Then returns the latency metric as 'udf.latency' here.
https://github.com/cmu-db/ottertune/blob/87c356655a4030123d4eec8b72453d4c12e49937/server/website/website/parser/postgres.py#L71-L73

For throughput, we want to divide the changes by the observation time. But we only want the changes in for latency metric. To do that, you should specify pg_stat_database.xact_commit metric_type as '1' (i.e. COUNTER), and specify udf.latency metric_type as '3' (i.e.STATISTICS) in metrics fixture.  We address it in convert_dbms_metrics function in  server/website/website/parser/base.py for these two cases.

You can define your own target objective and use your monitoring tools in this way. 