### PR TITLE
add script for uploading training data

### DIFF
--- a/client/driver/fabfile.py
+++ b/client/driver/fabfile.py
@@ -168,6 +168,14 @@ def add_udf():
     local(cmd)
 
 
+@task
+def upload_batch():
+    cmd = 'python3 ./upload_batch.py {} {} {}/new_result/'.format(CONF['save_path'],
+                                                                  CONF['upload_code'],
+                                                                  CONF['upload_url'])
+    local(cmd)
+
+
 def _ready_to_start_controller():
     return (os.path.exists(CONF['oltpbench_log']) and
             'Warmup complete, starting measurements'

--- a/client/driver/upload_batch.py
+++ b/client/driver/upload_batch.py
@@ -1,0 +1,63 @@
+#
+# OtterTune - upload_batch.py
+#
+# Copyright (c) 2017-18, Carnegie Mellon University Database Group
+#
+import argparse
+import glob
+import logging
+import os
+import requests
+
+
+# Logging
+LOG = logging.getLogger(__name__)
+LOG.addHandler(logging.StreamHandler())
+LOG.setLevel(logging.INFO)
+
+
+# Upload all files in the datadir to OtterTune's server side.
+# You may want to upload your training data to the non-tuning session.
+def upload_batch(datadir, upload_code, url):
+
+    samples = glob.glob(os.path.join(datadir, '*__summary.json'))
+    count = len(samples)
+    samples_prefix = []
+
+    LOG.info('Uploading %d samples in %s...', count, datadir)
+    for sample in samples:
+        prefix = sample.split('/')[-1].split('__')[0]
+        samples_prefix.append(prefix)
+
+    for i in range(count):
+        prefix = samples_prefix[i]
+        params = {
+            'summary': open(os.path.join(datadir, '{}__summary.json'.format(prefix)), 'rb'),
+            'knobs': open(os.path.join(datadir, '{}__knobs.json'.format(prefix)), 'rb'),
+            'metrics_before': open(os.path.join(datadir,
+                                                '{}__metrics_before.json'.format(prefix)), 'rb'),
+            'metrics_after': open(os.path.join(datadir,
+                                               '{}__metrics_after.json'.format(prefix)), 'rb'),
+        }
+
+        LOG.info('Upload %d-th sample %s__*.json', i + 1, prefix)
+        response = requests.post(url,
+                                 files=params,
+                                 data={'upload_code': upload_code})
+        LOG.info(response.content)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Upload generated data to the website")
+    parser.add_argument('datadir', type=str, nargs=1,
+                        help='Directory containing the generated data')
+    parser.add_argument('upload_code', type=str, nargs=1,
+                        help='The website\'s upload code')
+    parser.add_argument('url', type=str, default='http://0.0.0.0:8000/new_result/',
+                        nargs='?', help='The upload url: server_ip/new_result/')
+    args = parser.parse_args()
+    upload_batch(args.datadir[0], args.upload_code[0], args.url)
+
+
+if __name__ == "__main__":
+    main()

--- a/server/website/website/models.py
+++ b/server/website/website/models.py
@@ -201,11 +201,8 @@ class Session(BaseModel):
     nondefault_settings = models.TextField(null=True)
 
     def clean(self):
-        if self.tuning_session:
-            if self.target_objective is None:
-                self.target_objective = MetricManager.get_default_objective_function()
-        else:
-            self.target_objective = None
+        if self.target_objective is None:
+            self.target_objective = MetricManager.get_default_objective_function()
 
     def delete(self, using=DEFAULT_DB_ALIAS, keep_parents=False):
         targets = KnobData.objects.filter(session=self)

--- a/server/website/website/templates/edit_session.html
+++ b/server/website/website/templates/edit_session.html
@@ -50,7 +50,7 @@
 <script language="javascript">
 function show_content() {
 	console.log("In show_content()")
-	$("#target_obj_row").toggle()
+	//$("#target_obj_row").toggle()
 }
 
 $(function() {
@@ -61,11 +61,11 @@ $(function() {
 		$("#upload_code_row").hide();
 	}
 	
-	if (document.getElementById('id_tuning_session').checked) {
+	/*if (document.getElementById('id_tuning_session').checked) {
 		$("#target_obj_row").show()
 	} else {
 		$("#target_obj_row").hide()
-	}
+	}*/
 });
 </script>
 

--- a/server/website/website/templates/session.html
+++ b/server/website/website/templates/session.html
@@ -42,12 +42,10 @@
         <td><div class="text-right">{{ labels.tuning_session }}</div></td>
         <td>{{ session.tuning_session }}</td>
     </tr>
-    {% if session.tuning_session %}
     <tr>
         <td><div class="text-right">{{ labels.target_objective }}</div></td>
         <td>{{ metric_meta|get_item:session.target_objective|get_attr:"pprint" }}</td>
     </tr>
-    {% endif %}
     </tbody>
 </table>
 </div>


### PR DESCRIPTION
(1) When running `fab run_loops` in the client side, you can save the data in `save_path` by calling `save_dbms_result` function.  When you start a new OtterTune server, you can upload these data as training data by using this script, or calling `upload_batch` in the fab file. 

(2) target_objective is needed for both tuning and non-tuning session.