### PR TITLE
fix workload

### DIFF
--- a/server/website/tests/test_tasks.py
+++ b/server/website/tests/test_tasks.py
@@ -7,7 +7,7 @@ import copy
 import numpy as np
 from django.test import TestCase, override_settings
 
-from website.models import Workload, PipelineRun, PipelineData
+from website.models import Workload, PipelineRun, PipelineData, Result
 from website.tasks.periodic_tasks import (run_background_tasks,
                                           aggregate_data,
                                           run_workload_characterization,
@@ -69,7 +69,8 @@ class AggregateTestCase(TestCase):
     def testValidWorkload(self):
         workloads = Workload.objects.all()
         valid_workload = workloads[0]
-        dicts = aggregate_data(valid_workload)
+        wkld_results = Result.objects.filter(workload=valid_workload)
+        dicts = aggregate_data(wkld_results)
         keys = ['data', 'rowlabels', 'columnlabels']
         for d in dicts:
             for k in keys:
@@ -82,7 +83,8 @@ class PrunedMetricTestCase(TestCase):
 
     def testValidPrunedMetrics(self):
         workloads = Workload.objects.all()
-        metric_data = aggregate_data(workloads[0])[1]
+        wkld_results = Result.objects.filter(workload=workloads[0])
+        metric_data = aggregate_data(wkld_results)[1]
         pruned_metrics = run_workload_characterization(metric_data)
         for m in pruned_metrics:
             self.assertIn(m, metric_data['columnlabels'])
@@ -94,7 +96,8 @@ class RankedKnobTestCase(TestCase):
 
     def testValidImportantKnobs(self):
         workloads = Workload.objects.all()
-        knob_data, metric_data = aggregate_data(workloads[0])
+        wkld_results = Result.objects.filter(workload=workloads[0])
+        knob_data, metric_data = aggregate_data(wkld_results)
 
         # instead of doing actual metric pruning by factor analysis / clustering,
         # just randomly select 5 nonconstant metrics

--- a/server/website/website/models.py
+++ b/server/website/website/models.py
@@ -303,6 +303,18 @@ class Workload(BaseModel):
     hardware = models.ForeignKey(Hardware)
     name = models.CharField(max_length=128, verbose_name='workload name')
 
+    def delete(self, using=DEFAULT_DB_ALIAS, keep_parents=False):
+        # The results should not have corresponding workloads.
+        # results = Result.objects.filter(workload=self)
+        # if results.exists():
+        #     raise Exception("Cannot delete {} workload since results exist. ".format(self.name))
+
+        # Delete PipelineData with corresponding workloads
+        pipelinedatas = PipelineData.objects.filter(workload=self)
+        for x in pipelinedatas:
+            x.delete()
+        super(Workload, self).delete(using, keep_parents)
+
     class Meta:  # pylint: disable=old-style-class,no-init
         unique_together = ("dbms", "hardware", "name")
 

--- a/server/website/website/tasks/periodic_tasks.py
+++ b/server/website/website/tasks/periodic_tasks.py
@@ -41,8 +41,15 @@ def run_background_tasks():
     pipeline_run_obj.save()
 
     for workload in unique_workloads:
+
+        wkld_results = Result.objects.filter(workload=workload)
+        if wkld_results.exists() is False:
+            # delete the workload
+            workload.delete()
+            continue
+
         # Aggregate the knob & metric data for this workload
-        knob_data, metric_data = aggregate_data(workload)
+        knob_data, metric_data = aggregate_data(wkld_results)
 
         # Knob_data and metric_data are 2D numpy arrays. Convert them into a
         # JSON-friendly (nested) lists and then save them as new PipelineData
@@ -106,17 +113,14 @@ def run_background_tasks():
     pipeline_run_obj.save()
 
 
-def aggregate_data(workload):
+def aggregate_data(wkld_results):
     # Aggregates both the knob & metric data for the given workload.
     #
     # Parameters:
-    #   workload: aggregate data belonging to this specific workload
+    #   wkld_results: result data belonging to this specific workload
     #
     # Returns: two dictionaries containing the knob & metric data as
     # a tuple
-
-    # Find the results for this workload
-    wkld_results = Result.objects.filter(workload=workload)
 
     # Now call the aggregate_data helper function to combine all knob &
     # metric data into matrices and also create row/column labels


### PR DESCRIPTION
Delete workloads when all the corresponding results are deleted. 

In the tuning task, its workload is mapped to one of the existing workloads in the training data, which are updated when running periodic tasks.

Partially fix #104 