### PR TITLE
fix max val

### DIFF
--- a/server/website/website/tasks/async_tasks.py
+++ b/server/website/website/tasks/async_tasks.py
@@ -337,7 +337,7 @@ def configuration_recommendation(target_data):
             col_max = X_scaled[:, i].max()
             if X_columnlabels[i] in knobs_mem_catalog:
                 X_mem[0][i] = mem_max * 1024 * 1024 * 1024  # mem_max GB
-                col_max = X_scaler.transform(X_mem)[0][i]
+                col_max = min(col_max, X_scaler.transform(X_mem)[0][i])
 
             # Set min value to the default value
             # FIXME: support multiple methods can be selected by users


### PR DESCRIPTION
If hardware memory is smaller than the max value of memory-related tuning knobs, set the max value as memory size.