### PR TITLE
Bugfix for _ready_to_shut_down_controller in fabfile.py

### DIFF
--- a/client/driver/fabfile.py
+++ b/client/driver/fabfile.py
@@ -233,7 +233,7 @@ def _ready_to_start_controller():
 def _ready_to_shut_down_controller():
     pid_file_path = '../controller/pid.txt'
     return (os.path.exists(pid_file_path) and os.path.exists(CONF['oltpbench_log']) and
-            'Output into file' in open(CONF['oltpbench_log']).read())
+            'Output throughput samples into file' in open(CONF['oltpbench_log']).read())
 
 
 def clean_logs():


### PR DESCRIPTION
This is the issue running latest oltpbench code, the root cause is that [this commit](https://github.com/oltpbenchmark/oltpbench/commit/d8ad0a35da6d34ec9902a1589a198225b68fb299#diff-ddceeebf3cc1804f8af91035d0ecf597L743) by removed the original words in the log.

I found the projects under cmu-db are interdependent. There are some of my suggestions:
 - Don't match lines in the log file. For example, use subprocess or threads to monitor the states of the tasks.
 - Version control of the indepedent projects such as oltpbench and the projects which depend on these only rely on the released version. 
 - Cross projects CI. Might be tricky and also costy(Everytime A has a commit, not only trigger A's CI, but also trigger B(who has dependency on A under cmu-db unbrella)'s CI, not sure github could support monitoring other repo's hook).