### PR TITLE
fix minor bugs in server management files

### DIFF
--- a/server/analysis/tests/test_ddpg.py
+++ b/server/analysis/tests/test_ddpg.py
@@ -17,9 +17,9 @@ class TestDDPG(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        torch.manual_seed(0)
         random.seed(0)
         np.random.seed(0)
+        torch.manual_seed(0)
         super(TestDDPG, cls).setUpClass()
         boston = datasets.load_boston()
         data = boston['data']
@@ -38,5 +38,5 @@ class TestDDPG(unittest.TestCase):
         cls.ypreds_round = ['%.4f' % ddpg.choose_action(x)[0] for x in X_test]
 
     def test_ddpg_ypreds(self):  
-        expected_ypreds = ['0.1770', '0.3154', '0.3056', '0.4503', '0.5706', '0.4069']
+        expected_ypreds = ['0.3169', '0.3240', '0.3934', '0.5787', '0.6988', '0.5163']
         self.assertEqual(self.ypreds_round, expected_ypreds)

--- a/server/analysis/tests/test_ddpg.py
+++ b/server/analysis/tests/test_ddpg.py
@@ -37,6 +37,6 @@ class TestDDPG(unittest.TestCase):
                 ddpg.update()
         cls.ypreds_round = ['%.4f' % ddpg.choose_action(x)[0] for x in X_test]
 
-    def test_ddpg_ypreds(self):  
+    def test_ddpg_ypreds(self):
         expected_ypreds = ['0.3169', '0.3240', '0.3934', '0.5787', '0.6988', '0.5163']
         self.assertEqual(self.ypreds_round, expected_ypreds)

--- a/server/analysis/tests/test_ddpg.py
+++ b/server/analysis/tests/test_ddpg.py
@@ -24,20 +24,19 @@ class TestDDPG(unittest.TestCase):
         boston = datasets.load_boston()
         data = boston['data']
         X_train = data[0:500]
-        cls.X_test = data[500:]
+        X_test = data[500:]
         y_train = boston['target'][0:500].reshape(500, 1)
-        cls.ddpg = DDPG(n_actions=1, n_states=13)
+        ddpg = DDPG(n_actions=1, n_states=13)
         for i in range(500):
             knob_data = np.array([random.random()])
             prev_metric_data = X_train[i - 1]
             metric_data = X_train[i]
             reward = y_train[i - 1]
-            cls.ddpg.add_sample(prev_metric_data, knob_data, reward, metric_data, False)
-            if len(cls.ddpg.replay_memory) > 32:
-                cls.ddpg.update()
+            ddpg.add_sample(prev_metric_data, knob_data, reward, metric_data, False)
+            if len(ddpg.replay_memory) > 32:
+                ddpg.update()
+        cls.ypreds_round = ['%.4f' % ddpg.choose_action(x)[0] for x in X_test]
 
-    def test_ddpg_ypreds(self):
-        ypreds_round = [round(self.ddpg.choose_action(x)[0], 4) for x in self.X_test]
-        expected_ypreds = [0.1778, 0.1914, 0.2607, 0.4459, 0.5660, 0.3836]
-        for ypred_round, expected_ypred in zip(ypreds_round, expected_ypreds):
-            self.assertAlmostEqual(ypred_round, expected_ypred, places=6)
+    def test_ddpg_ypreds(self):  
+        expected_ypreds = ['0.1770', '0.3154', '0.3056', '0.4503', '0.5706', '0.4069']
+        self.assertEqual(self.ypreds_round, expected_ypreds)

--- a/server/website/script/management/fabfile.py
+++ b/server/website/script/management/fabfile.py
@@ -13,8 +13,11 @@ import logging
 from collections import namedtuple
 from fabric.api import env, local, quiet, settings, task
 from fabric.state import output as fabric_output
-
-from website.settings import DATABASES, PROJECT_ROOT
+import os
+import sys
+sys.path.append("../../")
+from website.settings import DATABASES, PROJECT_ROOT  # pylint: disable=wrong-import-position
+os.chdir("../../")
 
 LOG = logging.getLogger(__name__)
 
@@ -115,7 +118,6 @@ def reset_website():
         user, passwd, name))
 
     # Reinitialize the website
-    local('python manage.py migrate website')
     local('python manage.py migrate')
 
 

--- a/server/website/website/management/commands/stopcelery.py
+++ b/server/website/website/management/commands/stopcelery.py
@@ -11,7 +11,7 @@ from fabric.api import local
 
 
 class Command(BaseCommand):
-    help = 'Start celery and celerybeat in the background.'
+    help = 'Stop celery and celerybeat and remove pid files.'
     celery_cmd = 'python3 manage.py {cmd} {opts} &'.format
     max_wait_sec = 15
 


### PR DESCRIPTION
-- Since the fabfile is moved to another folder, it cannot work properly. In order to fix that, I set the working directory in the fabfile.
-- There is a django_db_logger migration which must be performed before the website migration, so I remove the redundent and failing website migration in the fabfile.
-- The documentation in stopcelery.py is wrong.

A sad thing is that your changes in the website model is not backward compatible and I cannot open my previous sessions on the website. When I try to redo the 0001_initial migration, to my surprise, django also undos the 0003_generate_fixture migration and all my experiments data on that machine losts.  (╥﹏╥)