### PR TITLE
dump and load session knob tunability

### DIFF
--- a/server/website/website/management/commands/dumpknob.py
+++ b/server/website/website/management/commands/dumpknob.py
@@ -1,5 +1,5 @@
 #
-# OtterTune - loadknobtunability.py
+# OtterTune - dumpknob.py
 #
 # Copyright (c) 2017-18, Carnegie Mellon University Database Group
 #
@@ -12,7 +12,7 @@ from website.models import Session, SessionKnob, SessionKnobManager
 
 
 class Command(BaseCommand):
-    help = 'load session tunability for the session with the given upload code.'
+    help = 'Dump knobs for the session with the given upload code.'
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -22,12 +22,12 @@ class Command(BaseCommand):
         parser.add_argument(
             '-f', '--filename',
             metavar='FILE',
-            help='Name of the file to read the session knob tunability from. '
+            help='Name of the file to write the session knob tunability to. '
                  'Default: knob.json')
         parser.add_argument(
             '-d', '--directory',
             metavar='DIR',
-            help='Path of the directory to read the session knob tunability from. '
+            help='Path of the directory to write the session knob tunability to. '
                  'Default: current directory')
 
     def handle(self, *args, **options):
@@ -40,13 +40,13 @@ class Command(BaseCommand):
             raise CommandError(
                 "ERROR: Session with upload code '{}' not exist.".format(options['uploadcode']))
 
+        session_knobs = SessionKnobManager.get_knob_min_max_tunability(session)
+
         filename = options['filename'] or 'knobs.json'
         path = os.path.join(directory, filename)
 
-        with open(path, 'r') as f:
-            knobs = json.load(f)
-
-        SessionKnobManager.set_knob_tunability(session, knobs)
+        with open(path, 'w') as f:
+            json.dump(session_knobs, f, indent=4)
 
         self.stdout.write(self.style.SUCCESS(
-            "Successfully load knob tunability from '{}'.".format(path)))
+            "Successfully dumped knob information to '{}'.".format(path)))

--- a/server/website/website/management/commands/loadknob.py
+++ b/server/website/website/management/commands/loadknob.py
@@ -1,5 +1,5 @@
 #
-# OtterTune - dumpknobtunability.py
+# OtterTune - loadknob.py
 #
 # Copyright (c) 2017-18, Carnegie Mellon University Database Group
 #
@@ -12,7 +12,7 @@ from website.models import Session, SessionKnob, SessionKnobManager
 
 
 class Command(BaseCommand):
-    help = 'Dump knob tunability for the session with the given upload code.'
+    help = 'load knobs for the session with the given upload code.'
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -22,12 +22,12 @@ class Command(BaseCommand):
         parser.add_argument(
             '-f', '--filename',
             metavar='FILE',
-            help='Name of the file to write the session knob tunability to. '
+            help='Name of the file to read the session knob tunability from. '
                  'Default: knob.json')
         parser.add_argument(
             '-d', '--directory',
             metavar='DIR',
-            help='Path of the directory to write the session knob tunability to. '
+            help='Path of the directory to read the session knob tunability from. '
                  'Default: current directory')
 
     def handle(self, *args, **options):
@@ -40,13 +40,13 @@ class Command(BaseCommand):
             raise CommandError(
                 "ERROR: Session with upload code '{}' not exist.".format(options['uploadcode']))
 
-        session_knobs = SessionKnobManager.get_knob_tunability(session)
-
         filename = options['filename'] or 'knobs.json'
         path = os.path.join(directory, filename)
 
-        with open(path, 'w') as f:
-            json.dump(session_knobs, f, indent=4)
+        with open(path, 'r') as f:
+            knobs = json.load(f)
+
+        SessionKnobManager.set_knob_min_max_tunability(session, knobs)
 
         self.stdout.write(self.style.SUCCESS(
-            "Successfully dumped knob tunability to '{}'.".format(path)))
+            "Successfully load knob information from '{}'.".format(path)))

--- a/server/website/website/management/commands/loadknobtunability.py
+++ b/server/website/website/management/commands/loadknobtunability.py
@@ -1,38 +1,34 @@
 #
-# OtterTune - dumpdebuginfo.py
+# OtterTune - loadknobtunability.py
 #
 # Copyright (c) 2017-18, Carnegie Mellon University Database Group
 #
+import json
 import os
 
 from django.core.management.base import BaseCommand, CommandError
 
-from website.models import Session
-from website.utils import dump_debug_info
+from website.models import Session, SessionKnob, SessionKnobManager
 
 
 class Command(BaseCommand):
-    help = 'Dump debug information for the session with the given upload code.'
+    help = 'load session tunability for the session with the given upload code.'
 
     def add_arguments(self, parser):
         parser.add_argument(
             'uploadcode',
             metavar='UPLOADCODE',
-            help="The session's upload code to.")
+            help="The session's upload code.")
         parser.add_argument(
             '-f', '--filename',
             metavar='FILE',
-            help='Name of the file to write the debug information. '
-                 'Default: debug_[timestamp].tar.gz')
+            help='Name of the file to read the session knob tunability from. '
+                 'Default: knob.json')
         parser.add_argument(
             '-d', '--directory',
             metavar='DIR',
-            help='Path of the directory to write the debug information to. '
+            help='Path of the directory to read the session knob tunability from. '
                  'Default: current directory')
-        parser.add_argument(
-            '--prettyprint',
-            action='store_true',
-            help='Pretty print the output.')
 
     def handle(self, *args, **options):
         directory = options['directory'] or ''
@@ -44,15 +40,13 @@ class Command(BaseCommand):
             raise CommandError(
                 "ERROR: Session with upload code '{}' not exist.".format(options['uploadcode']))
 
-        debug_info, root = dump_debug_info(session, pretty_print=options['prettyprint'])
-
-        filename = options['filename'] or root
-        if not filename.endswith('.tar.gz'):
-            filename += '.tar.gz'
+        filename = options['filename'] or 'knobs.json'
         path = os.path.join(directory, filename)
 
-        with open(path, 'wb') as f:
-            f.write(debug_info.getvalue())
+        with open(path, 'r') as f:
+            knobs = json.load(f)
+
+        SessionKnobManager.set_knob_tunability(session, knobs)
 
         self.stdout.write(self.style.SUCCESS(
-            "Successfully dumped debug information to '{}'.".format(path)))
+            "Successfully load knob tunability from '{}'.".format(path)))

--- a/server/website/website/management/commands/resetwebsite.py
+++ b/server/website/website/management/commands/resetwebsite.py
@@ -1,0 +1,50 @@
+#
+# OtterTune - resetwebsite.py
+#
+# Copyright (c) 2017-18, Carnegie Mellon University Database Group
+#
+from django.core.management.base import BaseCommand
+from fabric.api import local
+from website.settings import DATABASES
+
+
+class Command(BaseCommand):
+    help = 'dump the website; reset the website; load data from file if specified.'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '-d', '--dumpfile',
+            metavar='FILE',
+            help='Name of the file to dump data to. '
+                 'Default: dump_website.json')
+        parser.add_argument(
+            '-l', '--loadfile',
+            metavar='FILE',
+            help='Name of the file to load data from. ')
+
+    def reset_website(self):
+        # WARNING: destroys the existing website and creates with all
+        # of the required inital data loaded (e.g., the KnobCatalog)
+    
+        # Recreate the ottertune database
+        user = DATABASES['default']['USER']
+        passwd = DATABASES['default']['PASSWORD']
+        name = DATABASES['default']['NAME']
+        local("mysql -u {} -p{} -N -B -e \"DROP DATABASE IF EXISTS {}\"".format(
+            user, passwd, name))
+        local("mysql -u {} -p{} -N -B -e \"CREATE DATABASE {}\"".format(
+            user, passwd, name))
+    
+        # Reinitialize the website
+        local('python manage.py migrate')
+
+    def handle(self, *args, **options):
+        dumpfile = options['dumpfile'] if options['dumpfile'] else 'dump_website.json'
+        local("python manage.py dumpdata admin auth django_db_logger djcelery sessions\
+               sites website > {}".format(dumpfile))
+        self.reset_website()
+        if options['loadfile']:
+            local("python manage.py loaddata '{}'".format(options['loadfile']))
+
+        self.stdout.write(self.style.SUCCESS(
+            "Successfully reset website."))

--- a/server/website/website/management/commands/stopcelery.py
+++ b/server/website/website/management/commands/stopcelery.py
@@ -11,7 +11,7 @@ from fabric.api import local
 
 
 class Command(BaseCommand):
-    help = 'Start celery and celerybeat in the background.'
+    help = 'Stop celery and celerybeat and remove pid files.'
     celery_cmd = 'python3 manage.py {cmd} {opts} &'.format
     max_wait_sec = 15
 

--- a/server/website/website/models.py
+++ b/server/website/website/models.py
@@ -194,24 +194,29 @@ class SessionKnobManager(models.Manager):
         return knob_dicts
 
     @staticmethod
-    def get_knob_tunability(session):
+    def get_knob_min_max_tunability(session):
         # Returns a dict of the knob
         knobs = KnobCatalog.objects.filter(dbms=session.dbms)
         knob_dicts = list(knobs.values())
-        session_knob_dict = {}
+        session_knob_dicts = {}
         for i, _ in enumerate(knob_dicts):
             if SessionKnob.objects.filter(session=session, knob=knobs[i]).exists():
                 new_knob = SessionKnob.objects.filter(session=session, knob=knobs[i])[0]
-                session_knob_dict[new_knob.name] = new_knob.tunable
-        return session_knob_dict
+                min_max_tunability = {"minval": new_knob.minval,
+                                      "maxval": new_knob.maxval,
+                                      "tunable": new_knob.tunable}
+                session_knob_dicts[new_knob.name] = min_max_tunability
+        return session_knob_dicts
 
     @staticmethod
-    def set_knob_tunability(session, knob_dicts):
+    def set_knob_min_max_tunability(session, knob_dicts):
         # Returns a dict of the knob
         session_knobs = SessionKnob.objects.filter(session=session)
         for session_knob in session_knobs:
             if knob_dicts.__contains__(session_knob.name):
-                session_knob.tunable = knob_dicts[session_knob.name]
+                session_knob.minval = knob_dicts[session_knob.name]["minval"]
+                session_knob.maxval = knob_dicts[session_knob.name]["maxval"]
+                session_knob.tunable = knob_dicts[session_knob.name]["tunable"]
                 session_knob.save()
 
 

--- a/server/website/website/models.py
+++ b/server/website/website/models.py
@@ -193,6 +193,27 @@ class SessionKnobManager(models.Manager):
         knob_dicts = [knob for knob in knob_dicts if knob["tunable"]]
         return knob_dicts
 
+    @staticmethod
+    def get_knob_tunability(session):
+        # Returns a dict of the knob
+        knobs = KnobCatalog.objects.filter(dbms=session.dbms)
+        knob_dicts = list(knobs.values())
+        session_knob_dict = {}
+        for i, _ in enumerate(knob_dicts):
+            if SessionKnob.objects.filter(session=session, knob=knobs[i]).exists():
+                new_knob = SessionKnob.objects.filter(session=session, knob=knobs[i])[0]
+                session_knob_dict[new_knob.name] = new_knob.tunable
+        return session_knob_dict
+
+    @staticmethod
+    def set_knob_tunability(session, knob_dicts):
+        # Returns a dict of the knob
+        session_knobs = SessionKnob.objects.filter(session=session)
+        for session_knob in session_knobs:
+            if knob_dicts.__contains__(session_knob.name):
+                session_knob.tunable = knob_dicts[session_knob.name]
+                session_knob.save()
+
 
 class SessionKnob(BaseModel):
 


### PR DESCRIPTION
- dump session knob to json
- load json, and modify session knobs
- dump and reset website
- load website

usage: 
`python manage.py dumpknob UPLOAD_CODE`
`python manage.py loadknob UPLOAD_CODE`
`python manage.py resetwebsite`

I have done some tests manually to make sure the behaviour is correct.