### PR TITLE
achieve stable performance and fix bugs

### DIFF
--- a/client/driver/configs/postgres_base.conf
+++ b/client/driver/configs/postgres_base.conf
@@ -1,0 +1,4 @@
+track_counts = on
+track_functions = all
+track_io_timing = on
+autovacuum = off

--- a/client/driver/driver_config.json
+++ b/client/driver/driver_config.json
@@ -3,6 +3,8 @@
   "database_name" : "tpcc",
   "database_disk": "",
   "database_conf": "/etc/postgresql/9.6/main/postgresql.conf",
+  "base_database_conf": "configs/postgres_base.conf",
+  "pg_datadir": "/var/lib/postgresql/9.6/main",
   "database_save_path": "~/ottertune/client/driver/dumpfiles",
   "username" : "dbuser",
   "password" : "dbpassword",
@@ -16,5 +18,7 @@
   "upload_code" : "I5I10PXK3PK27FM86YYS",
   "lhs_knob_path" : "~/ottertune/client/driver/knobs/postgres-96.json",
   "lhs_save_path" : "~/ottertune/client/driver/configs",
-  "oracle_awr_enabled": false
+  "oracle_awr_enabled": false,
+  "warmup_iterations": 0,
+  "sleep_time": 300
 }

--- a/client/driver/fabfile.py
+++ b/client/driver/fabfile.py
@@ -518,7 +518,7 @@ def loop(i):
     # stop the experiment
     while not _ready_to_shut_down_controller():
         time.sleep(1)
-    
+
     signal_controller()
     LOG.info('Start the second collection, shut down the controller')
 
@@ -536,10 +536,10 @@ def loop(i):
 
         # get result
         response = get_result()
-    
+
         # save next config
         save_next_config(response, t=result_timestamp)
-    
+
         # change config
         change_conf(response['recommendation'])
 


### PR DESCRIPTION
- warmup_iterations: run workload but does not upload result
- sleep_time: after restart database, wait a few minutes
- user can define basic database config
- allow longer restart time (by default, if restart does not finish in 1 minute, it fails)
- explicitly use fast mode for restart, which performs a checkpoint before shutdown
- start the database before reloading the database, otherwise it could fail
- move pd_datadir to driver_conf