### PR TITLE
change knob catelog when changing session knob tunability

### DIFF
--- a/server/website/website/models.py
+++ b/server/website/website/models.py
@@ -211,7 +211,7 @@ class SessionKnobManager(models.Manager):
         return session_knob_dicts
 
     @staticmethod
-    def set_knob_min_max_tunability(session, knob_dicts, disable_others=False):
+    def set_knob_min_max_tunability(session, knob_dicts, cascade=True, disable_others=False):
         # Returns a dict of the knob
         session_knobs = SessionKnob.objects.filter(session=session)
         for session_knob in session_knobs:
@@ -220,6 +220,11 @@ class SessionKnobManager(models.Manager):
                 session_knob.maxval = knob_dicts[session_knob.name]["maxval"]
                 session_knob.tunable = knob_dicts[session_knob.name]["tunable"]
                 session_knob.save()
+                if cascade:
+                    knob = KnobCatalog.objects.get(name=session_knob.name,
+                                                   dbms=session_knob.session.dbms)
+                    knob.tunable = session_knob.tunable
+                    knob.save()
             elif disable_others:
                 # Set all knobs not in knob_dicts to not tunable
                 session_knob.tunable = False


### PR DESCRIPTION
I also have a list of 70 postgres knobs with correct min/max.