### PR TITLE
Handling Database Restart Error

### DIFF
--- a/client/driver/fabfile.py
+++ b/client/driver/fabfile.py
@@ -538,7 +538,7 @@ def loop(i):
                  'metrics_before': b'{}',
                  'metrics_after': b'{}'}
         response = requests.post(dconf.WEBSITE_URL + '/new_result/', files=files,
-                             data={'upload_code': dconf.UPLOAD_CODE})
+                                 data={'upload_code': dconf.UPLOAD_CODE})
         response = get_result()
         result_timestamp = int(time.time())
         save_next_config(response, t=result_timestamp)

--- a/client/driver/fabfile.py
+++ b/client/driver/fabfile.py
@@ -127,7 +127,7 @@ def restart_database():
         return False
     else:
         raise Exception("Database Type {} Not Implemented !".format(dconf.DB_TYPE))
-    return True
+    return False
 
 
 @task

--- a/client/driver/fabfile.py
+++ b/client/driver/fabfile.py
@@ -530,17 +530,17 @@ def loop(i):
 
     # remove oltpbench log and controller log
     clean_logs()
-
     # restart database
     restart_succeeded = restart_database()
     if not restart_succeeded:
-        files = {'summary':b'{error:"DB_RESTART_ERROR"}',
-                 'knobs':b'',
-                 'metrics_before':b'',
-                 'metrics_after':b''}
+        files = {'summary': b'{"error": "DB_RESTART_ERROR"}',
+                 'knobs': b'{}',
+                 'metrics_before': b'{}',
+                 'metrics_after': b'{}'}
         response = requests.post(dconf.WEBSITE_URL + '/new_result/', files=files,
                              data={'upload_code': dconf.UPLOAD_CODE})
         response = get_result()
+        result_timestamp = int(time.time())
         save_next_config(response, t=result_timestamp)
         change_conf(response['recommendation'])
         return

--- a/client/driver/fabfile.py
+++ b/client/driver/fabfile.py
@@ -127,7 +127,7 @@ def restart_database():
         return False
     else:
         raise Exception("Database Type {} Not Implemented !".format(dconf.DB_TYPE))
-    return False
+    return True
 
 
 @task

--- a/client/driver/oracleScripts/restartOracle.sh
+++ b/client/driver/oracleScripts/restartOracle.sh
@@ -1,8 +1,11 @@
 #!/bin/sh
+LOGFILE="$1"
 
 sqlplus / as sysdba <<EOF
 shutdown immediate
+spool $LOGFILE
 startup
+spool off
 quit
 EOF
 

--- a/server/website/website/views.py
+++ b/server/website/website/views.py
@@ -457,7 +457,7 @@ def handle_result_files(session, files):
     summary = JSONUtil.loads(files['summary'])
 
     # If database crashed on restart, pull latest result and worst throughput so far
-    if 'error' in summary and summary['error']=="DB_RESTART_ERROR":
+    if 'error' in summary and summary['error'] == "DB_RESTART_ERROR":
 
         LOG.debug("Error in restarting database")
         # Find worst throughput
@@ -467,13 +467,13 @@ def handle_result_files(session, files):
             throughput = JSONUtil.loads(curr_config.data)[session.target_objective]
             metric_meta = target_objectives.get_instance(
                 session.dbms.pk, session.target_objective)
-            if metric_meta.improvement==target_objectives.MORE_IS_BETTER:
+            if metric_meta.improvement == target_objectives.MORE_IS_BETTER:
                 if worst_throughput is None or throughput < worst_throughput:
                     worst_throughput = throughput
             else:
                 if worst_throughput is None or throughput > worst_throughput:
                     worst_throughput = throughput
-        LOG.debug("Worst throughput so far is:%d",worst_throughput)
+        LOG.debug("Worst throughput so far is:%d", worst_throughput)
 
         result = Result.objects.filter(session=session).order_by("-id").first()
         backup_data = BackupData.objects.filter(result=result).first()
@@ -495,12 +495,14 @@ def handle_result_files(session, files):
             for tunable_knob in last_conf.keys():
                 if tunable_knob in knob:
                     unit = KnobCatalog.objects.get(dbms=session.dbms, name=knob).unit
+                    bytes_system = ConversionUtil.DEFAULT_BYTES_SYSTEM
+                    time_system = ConversionUtil.DEFAULT_TIME_SYSTEM
                     if unit == 1:
                         data_knobs[knob] = ConversionUtil.get_raw_size(last_conf[tunable_knob],
-                                                                       ConversionUtil.DEFAULT_BYTES_SYSTEM)
+                                                                       bytes_system)
                     elif unit == 2:
                         data_knobs[knob] = ConversionUtil.get_raw_size(last_conf[tunable_knob],
-                                                                       ConversionUtil.DEFAULT_TIME_SYSTEM)
+                                                                       time_system)
                     else:
                         data_knobs[knob] = last_conf[tunable_knob]
 
@@ -512,7 +514,7 @@ def handle_result_files(session, files):
 
         metric_data = result.metric_data
         metric_cpy = JSONUtil.loads(metric_data.data)
-        metric_cpy["throughput_txn_per_sec"]=worst_throughput
+        metric_cpy["throughput_txn_per_sec"] = worst_throughput
         metric_cpy = JSONUtil.dumps(metric_cpy)
         metric_data.pk = None
         metric_data.name = metric_data.name + '*'


### PR DESCRIPTION
Fixed ottertune so that when the database crashes on restart, the system regards it as if it had observed the worst throughput seen so far. This allows the machine learning to continue even if the knobs get too large.