### PR TITLE
Check celery on each request for result

### DIFF
--- a/server/website/website/management/commands/startcelery.py
+++ b/server/website/website/management/commands/startcelery.py
@@ -14,7 +14,7 @@ from fabric.api import hide, lcd, local
 class Command(BaseCommand):
     help = 'Start celery and celerybeat in the background.'
     celery_cmd = 'python3 manage.py {cmd} {opts} {pipe} &'.format
-    max_wait_sec = 15
+    max_wait_sec = 60
 
     def add_arguments(self, parser):
         group = parser.add_mutually_exclusive_group()
@@ -124,7 +124,7 @@ class Command(BaseCommand):
         for name in ('celery', 'celerybeat'):
             if os.path.exists(options[name + '_pidfile']):
                 self.stdout.write(self.style.SUCCESS(
-                    "Successfully started '{}'.".format(name)))
+                    "Successfully started '{}' in {} seconds.".format(name, wait_sec)))
             else:
                 self.stdout.write(self.style.NOTICE(
                     "Failed to start '{}'.".format(name)))

--- a/server/website/website/settings/common.py
+++ b/server/website/website/settings/common.py
@@ -240,6 +240,10 @@ CELERYD_MAX_TASKS_PER_CHILD = 20
 # Number of concurrent workers. Defaults to the number of CPUs.
 # CELERYD_CONCURRENCY = 8
 
+# Late ack means the task messages will be acknowledged after
+# the task has been executed, not just before
+CELERY_ACKS_LATE = True
+
 djcelery.setup_loader()
 
 # ==============================================

--- a/server/website/website/utils.py
+++ b/server/website/website/utils.py
@@ -513,6 +513,13 @@ def check_and_run_celery():
     if 'pong' in celery_status:
         return 'celery is running'
 
+    rabbitmq_status = os.popen('telnet localhost 5672').read()
+    if 'Connected' in rabbitmq_status:
+        LOG.info('Rabbitmq is running.')
+    else:
+        LOG.warning('Rabbitmq is not running.')
+        return 'Rabbitmq is not running.'
+
     retries = 0
     while retries < 5:
         LOG.warning('Celery is not running.')

--- a/server/website/website/views.py
+++ b/server/website/website/views.py
@@ -1194,8 +1194,11 @@ def give_result(request, upload_code):  # pylint: disable=unused-argument
             status_code = 200
 
     else:  # One or more tasks are still waiting to execute
-        response.update(celery_status='PENDING', message='Result not ready')
-        status_code = 202
+        celery_status = 'PENDING'
+        if CHECK_CELERY:
+            celery_status = utils.check_and_run_celery()
+        response.update(celery_status=celery_status, message='Result not ready')
+        status_code = 202 
 
     return HttpResponse(JSONUtil.dumps(response, pprint=True), status=status_code,
                         content_type='application/json')

--- a/server/website/website/views.py
+++ b/server/website/website/views.py
@@ -1198,7 +1198,7 @@ def give_result(request, upload_code):  # pylint: disable=unused-argument
         if CHECK_CELERY:
             celery_status = utils.check_and_run_celery()
         response.update(celery_status=celery_status, message='Result not ready')
-        status_code = 202 
+        status_code = 202
 
     return HttpResponse(JSONUtil.dumps(response, pprint=True), status=status_code,
                         content_type='application/json')


### PR DESCRIPTION
This is a further attempt to address the celery error which Sebastian still encounters. I think of 4 possible causes for this error:
- Celery is not running before running a tuning task (this type of error is fixed in the previous PR)
- Celery dies when it is running a tuning task (this type of error is not considered in the previous PR)
- For some reason, Celery can never start. 
- Celery is running, but rabbitmq server is not running, so Celery cannot work

*I fixed the second kind of error in this PR*: 
- set `CELERY_ACKS_LATE=True`, so that an incomplete task is still in the queue for retrying. Without this option, when celery is killed, the running task is lost forever.
- every time the client pings the server for results, I check the Celery status and restart Celery if it is down.
- I also examine the fourth kind of error. I have added code to test if rabbitmq is running by connecting the port 5672. We get a warning if it is not running.

Tests:
I inserted codes in a few positions in async_task.py to kill Celery. Without the fixes in this PR the task fails. With the fixes here the task succeeds.

However, I am worried that Sebastian's error is more like the third kind, because there are error message as follows:
`Failed to start 'celery'.
Failed to start 'celerybeat'.`
It means there is no pid file for celery worker and celerybeat. I do not really know what can be a potential cause for that. At least when rabbitmq is not running, celery can still come up and generate the pid files.
The only reason I can think of is that the waiting time is shorter than needed. So I increased it from 15 seconds to 60 seconds, and I log the waiting time to see if it is long or not.