### PR TITLE
Sort aggregated matrix columns by knob/metric name

### DIFF
--- a/server/website/website/utils.py
+++ b/server/website/website/utils.py
@@ -148,8 +148,8 @@ class DataUtil(object):
     def aggregate_data(results, ignore=None):
         if ignore is None:
             ignore = ['range_test']
-        knob_labels = list(JSONUtil.loads(results[0].knob_data.data).keys())
-        metric_labels = list(JSONUtil.loads(results[0].metric_data.data).keys())
+        knob_labels = sorted(JSONUtil.loads(results[0].knob_data.data).keys())
+        metric_labels = sorted(JSONUtil.loads(results[0].metric_data.data).keys())
         X_matrix = []
         y_matrix = []
         rowlabels = []
@@ -163,12 +163,14 @@ class DataUtil(object):
                     ("Incorrect number of knobs "
                      "(expected={}, actual={})").format(len(knob_labels),
                                                         len(param_data)))
+
             metric_data = JSONUtil.loads(result.metric_data.data)
             if len(metric_data) != len(metric_labels):
                 raise Exception(
                     ("Incorrect number of metrics "
                      "(expected={}, actual={})").format(len(metric_labels),
                                                         len(metric_data)))
+
             X_matrix.append([param_data[l] for l in knob_labels])
             y_matrix.append([metric_data[l] for l in metric_labels])
             rowlabels.append(result.pk)


### PR DESCRIPTION
The aggregate_data method assumes the knob/metric JSON data stored in the [Knob|Metric|Pipeline]Data.data field is sorted which is sometimes violated and causing this error:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/celery/app/trace.py", line 240, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/celery/app/trace.py", line 438, in __protected_call__
    return self.run(*args, **kwargs)
  File "/app/website/website/tasks/async_tasks.py", line 939, in configuration_recommendation
    pipeline_metrics = combine_workload(target_data)
  File "/app/website/website/tasks/async_tasks.py", line 775, in combine_workload
    y_columnlabels, target_data['y_columnlabels'])
Exception: ('The workload and target data should have identical y columnlabels (sorted metric names)', array(['global.awr_begin_snap', 'global.awr_dbid', 'global.awr_end_snap',
       ..., 'raw_db_time', 'transaction_counter', 'elapsed_time'],
      dtype='<U106'), ['global.awr_begin_snap', 'global.awr_dbid', 'global.awr_end_snap', 'global.capture_id',
```
This assumption is not necessary - it's better to just sort the matrix columns in the aggregate_data method.