### PR TITLE
Background task improvements

### DIFF
--- a/server/website/website/admin.py
+++ b/server/website/website/admin.py
@@ -146,7 +146,7 @@ class TaskMetaAdmin(admin.ModelAdmin):
     fields = readonly_fields
     list_filter = ('status',)
     list_per_page = 10
-    ordering = ('date_done',)
+    ordering = ('-date_done',)
     max_field_length = 1000
 
     @staticmethod

--- a/server/website/website/admin.py
+++ b/server/website/website/admin.py
@@ -118,7 +118,7 @@ class PipelineDataAdmin(admin.ModelAdmin):
 
 class PipelineRunAdmin(admin.ModelAdmin):
     list_display = ('id', 'start_time', 'end_time')
-    ordering = ('id', 'start_time')
+    ordering = ('-id', '-start_time')
 
 
 class WorkloadAdmin(admin.ModelAdmin):
@@ -187,7 +187,9 @@ class CustomStatusLogAdmin(StatusLogAdmin):
 
 
 class ExecutionTimeAdmin(admin.ModelAdmin):
-    list_display = ('event', 'result', 'exec_time')
+    list_display = ('event', 'start_time', 'exec_time', 'result')
+    list_filter = ('module', 'function', 'tag')
+    ordering = ('-start_time',)
 
     def exec_time(self, instance):  # pylint: disable=no-self-use
         return '{:.0f} sec'.format(instance.execution_time)

--- a/server/website/website/settings/constants.py
+++ b/server/website/website/settings/constants.py
@@ -11,3 +11,16 @@ CHECK_CELERY = True
 
 # address categorical knobs (enum, boolean)
 ENABLE_DUMMY_ENCODER = False
+
+# Whether to include the pruned metrics from the workload characterization subtask in
+# the output (y) when ranking the knobs for a given workload in the knob identification
+# subtask.
+
+# When computing the ranked knobs in the knob identification subtask, the output (y) is
+# the set of target objectives used to tune the given workload. If this flag is enabled
+# then the pruned metrics from the workload characterization subtask are also included
+# in the output. (See website/tasks/periodic_tasks.py)
+KNOB_IDENT_USE_PRUNED_METRICS = False
+
+# The background tasks only process workloads containing this minimum amount of results
+MIN_WORKLOAD_RESULTS_COUNT = 5

--- a/server/website/website/tasks/periodic_tasks.py
+++ b/server/website/website/tasks/periodic_tasks.py
@@ -278,7 +278,7 @@ def run_workload_characterization(metric_data):
     # Fit factor analysis model
     fa_model = FactorAnalysis()
     # For now we use 5 latent variables
-    fa_model.fit(unique_matrix, unique_columnlabels, n_components=5)
+    fa_model.fit(shuffled_matrix, unique_columnlabels, n_components=5)
 
     # Components: metrics * factors
     components = fa_model.components_.T.copy()
@@ -302,6 +302,7 @@ def run_workload_characterization(metric_data):
 
     # Return pruned metrics
     save_execution_time(start_ts, "run_workload_characterization")
+    LOG.info("Workload characterization finished in %.0f seconds.", time.time() - start_ts)
     return pruned_metrics
 
 
@@ -384,4 +385,5 @@ def run_knob_identification(knob_data, metric_data, dbms):
     consolidated_knobs = consolidate_columnlabels(encoded_knobs)
 
     save_execution_time(start_ts, "run_knob_identification")
+    LOG.info("Knob identification finished in %.0f seconds.", time.time() - start_ts)
     return consolidated_knobs


### PR DESCRIPTION
Changes:
- By default, the knob identification task now uses the set of target objectives used to tune a particular workload as the output `y` instead of the pruned metrics.
- Added option `KNOB_IDENT_USE_PRUNED_METRICS` to constants.py. When enabled, pruned metrics are also included in the output `y` in the knob identification task. (It's disabled by default).
- Further reduced the number of metrics included as features when computing the workload characterization tasks by additionally filtering out non-unique columns and binning the metrics by deciles before removing constant/non-unique columns.
- Reversed the ordering in a couple of our admin views so newer objects show up first.