### PR TITLE
clean metrics for DDPG

### DIFF
--- a/server/website/website/settings/constants.py
+++ b/server/website/website/settings/constants.py
@@ -32,3 +32,9 @@ VIEWS_FOR_PRUNING = {
     DBMSType.ORACLE: ['dba_hist_osstat', 'dba_hist_sysstat', 'dba_hist_system_event',
                       'dba_workload_replays', 'dba_hist_sys_time_model'],
 }
+
+# The views used for DDPG
+# WARNING: modifying this parameter will cause all existing DDPG sessions broken
+VIEWS_FOR_DDPG = {
+    DBMSType.ORACLE: ['dba_hist_sys_time_model'],
+}

--- a/server/website/website/tasks/periodic_tasks.py
+++ b/server/website/website/tasks/periodic_tasks.py
@@ -269,16 +269,8 @@ def run_workload_characterization(metric_data, dbms=None):
     LOG.debug("Workload characterization ~ initial data size: %s", matrix.shape)
 
     views = None if dbms is None else VIEWS_FOR_PRUNING.get(dbms.type, None)
-    if views is not None:
-        useful_labels = []
-        for label in columnlabels:
-            for view in views:
-                if view in label:
-                    useful_labels.append(label)
-                    break
-        matrix, columnlabels = DataUtil.clean_metric_data(matrix, columnlabels, None,
-                                                          useful_labels)
-        LOG.debug("Workload characterization ~ cleaned data size: %s", matrix.shape)
+    matrix, columnlabels = DataUtil.clean_metric_data(matrix, columnlabels, views)
+    LOG.debug("Workload characterization ~ cleaned data size: %s", matrix.shape)
 
     # Bin each column (metric) in the matrix by its decile
     binner = Bin(bin_start=1, axis=0)


### PR DESCRIPTION
- prune metrics for DDPG:
I think the right way to go is to use a small set of metrics. Otherwise, DDPG can hardly to learn. Therefore, I pick dba_hist_sys_time_model, which can represent the workload and only has 31 metrics.
- clean up convert_dbms_metrics: 
remove unused base_metric_data; rename metric_data to numeric_metric_data; use all metric_data instead of numeric_metric_data to calculate target objectives.
- fix invalid results handling bug:
check if the last_conf is None before copying that to the knob file.